### PR TITLE
Replace explicit workflow step labels with use of function names

### DIFF
--- a/docs/docs/basics/manual-step-ordering.md
+++ b/docs/docs/basics/manual-step-ordering.md
@@ -1,38 +1,36 @@
-# Using workflow step labels
+# Using workflow step names for manual ordering
 
-Workflow steps may be manually ordered and redirected by use of `GoToStep` and step labels.
+Workflow steps may be manually ordered and redirected by use of `GoToStep` and step names.
 
-Workflow steps can be labelled by passing a `label` string as a keyword argument to the `step` decorator.
-
-Workflow ordering can be preempted and redirected by raising the `GoToStep` exception, passing either the workflow step label or its numeric index.
+Workflow ordering can be preempted and redirected by raising the `GoToStep` exception, passing either the workflow step function name or its numeric index.
 
 Workflows may also be advanced directly to completion by raising the `GoToEnd` exceptions.
 
 
-## Defining workflow labels
+## Defining manual workflow order
 
-The following workflow contains five steps in total, which are executed in a specific order as directed by the labels.
+The following workflow contains five steps in total, which are executed in a specific order as directed by the step names.
 
-```py title="my_labelled_workflow.py"
+```py title="my_ordered_workflow.py"
 from ergate import GoToEnd, GoToStep, Workflow
 
-workflow = Workflow(unique_name="my_second_workflow")
+workflow = Workflow(unique_name="my_ordered_workflow")
 
 @workflow.step
 def step_1() -> None:
     print("Hello, I am step 1")
 
-@workflow.step(label="step_2")
+@workflow.step
 def step_2() -> None:
     print("Hello, I am step 2")
     raise GoToStep("step_3")
 
-@workflow.step(label="step_5")
+@workflow.step
 def step_5() -> None:
     print("Hello, I am step 5")
     raise GoToEnd
 
-@workflow.step(label="step_3")
+@workflow.step
 def step_3() -> None:
     print("Hello, I am step 3")
 
@@ -65,15 +63,15 @@ Without the `GoToStep` and `GoToEnd` exceptions being utilised, this workflow wo
 5. `step_4`
 
 This trivial example may seem pointless, as one could readily move `step_5` to the end of the file and negate the need 
-for these exceptions and labels.  However, these features allow for branching of workflows according to arbitrary 
-conditions.
+for manual ordering with these exceptions.  However, these features allow for branching of workflows according to 
+arbitrary conditions.
 
 Consider the following bifurcated workflow.
 
-```py title="my_labelled_workflow.py"
+```py title="my_ordered_workflow_2.py"
 from ergate import GoToEnd, GoToStep, Workflow
 
-workflow = Workflow(unique_name="my_second_workflow")
+workflow = Workflow(unique_name="my_ordered_workflow_2")
 
 @workflow.step
 def step_1(input_value) -> None:
@@ -87,12 +85,12 @@ def step_1(input_value) -> None:
         case _:
             raise GoToStep("step_default2")
 
-@workflow.step(label="step_default")
+@workflow.step
 def step_default2() -> None:
     print("Hello, I am step default.2")
     raise GoToStep("step_4")
 
-@workflow.step(label="step_a2")
+@workflow.step
 def step_a2() -> None:
     print("Hello, I am step a.2")
 
@@ -101,7 +99,7 @@ def step_a3() -> None:
     print("Hello, I am step a.3")
     raise GoToStep("step_4")
 
-@workflow.step(label="step_b2")
+@workflow.step
 def step_b2() -> None:
     print("Hello, I am step b.2")
 
@@ -110,7 +108,7 @@ def step_b3() -> None:
     print("Hello, I am step b.3")
     raise GoToStep("step_4")
 
-@workflow.step(label="step_4")
+@workflow.step
 def step_4() -> None:
     print("Hello, I am step 4")
 ```
@@ -141,8 +139,8 @@ If `input_value` is anything else, the workflow path is:
 Note that the length of the workflows can vary.
 
 ## Errata
-* Because of how the `percent_completed` and `total_steps` values are calculated, utilising step labels and the related 
-exceptions can cause the percentage and total step calculations to be inaccurate.  It is recommended when utilising 
-these features to define the `paths` each step may follow, to allow Ergate to better calculate and predict values for 
-`percent_completed` and `total_steps`.  Although they will still not be fully accurate, they will be progressive (never 
-reducing back to a lower count of steps completed) and grow in accuracy as the workflow progresses. 
+* Because of how the `percent_completed` and `total_steps` values are calculated, utilising manual step ordering with 
+the related exceptions can cause the percentage and total step calculations to be inaccurate.  It is recommended when 
+utilising this feature to define the `paths` each step may follow, to allow Ergate to better calculate and predict 
+values for `percent_completed` and `total_steps`.  Although they will still not always be fully accurate, they will be 
+progressive (never reducing back to a lower count of steps completed) and grow in accuracy as the workflow progresses. 

--- a/ergate/exceptions.py
+++ b/ergate/exceptions.py
@@ -44,11 +44,11 @@ class GoToStep(ErgateError):  # noqa: N818
         return self.value
 
     @property
-    def is_label(self) -> bool:
+    def is_step_name(self) -> bool:
         return isinstance(self.value, str)
 
     @property
-    def label(self) -> str:
+    def step_name(self) -> str:
         assert isinstance(self.value, str)
         return self.value
 

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -44,7 +44,7 @@ class JobRunner(Generic[JobType]):
             LOG.info("User requested to abort job: %s", exc)
             job.mark_aborted(exc.message)
         except GoToEnd as exc:
-            print("===311.1===", "GoToEnd", dict(step_val=job.steps_completed, current_step=job.current_step, steps_completed=job.steps_completed, remaining_steps=0, total_steps=job.steps_completed))
+            print("===311.1===", "GoToEnd", dict(step_val=job.steps_completed, current_step=job.current_step, steps_completed=job.steps_completed, remaining_steps=0, total_steps=job.steps_completed + 1))
             job.mark_step_n_completed(
                 job.steps_completed, exc.retval, job.steps_completed + 1
             )

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -60,10 +60,10 @@ class JobRunner(Generic[JobType]):
                     exc.retval,
                 )
             else:
-                index = workflow.get_label_index(exc.label)
+                index = workflow.get_index_by_step_name(exc.step_name)
                 LOG.info(
                     "User requested to go to step: %s (%s) - return value: %s",
-                    exc.label,
+                    exc.step_name,
                     index,
                     exc.retval,
                 )

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -44,7 +44,6 @@ class JobRunner(Generic[JobType]):
             LOG.info("User requested to abort job: %s", exc)
             job.mark_aborted(exc.message)
         except GoToEnd as exc:
-            print("===311.1===", "GoToEnd", dict(step_val=job.steps_completed, current_step=job.current_step, steps_completed=job.steps_completed, remaining_steps=0, total_steps=job.steps_completed + 1))
             job.mark_step_n_completed(
                 job.steps_completed, exc.retval, job.steps_completed + 1
             )
@@ -79,8 +78,6 @@ class JobRunner(Generic[JobType]):
                 default=0,
             )
 
-            print("===311.2===", "GoToStep", dict(step_val=index, current_step=job.current_step, steps_completed=job.steps_completed, remaining_steps=remaining_steps, total_steps=job.steps_completed + remaining_steps))
-
             job.mark_step_n_completed(
                 index, exc.retval, job.steps_completed + remaining_steps
             )
@@ -96,8 +93,6 @@ class JobRunner(Generic[JobType]):
                 default=0,
             )
 
-            print("===311.3===", "SkipNSteps", dict(step_val=exc.n + 1, current_step=job.current_step, steps_completed=job.steps_completed, remaining_steps=remaining_steps, total_steps=job.steps_completed + remaining_steps))
-
             job.mark_n_steps_completed(
                 exc.n + 1, exc.retval, job.steps_completed + remaining_steps
             )
@@ -111,11 +106,8 @@ class JobRunner(Generic[JobType]):
                 map(len, filter(lambda steps: steps[0][0] is None, paths)), default=0
             )
 
-            print("===311.4===", "return", dict(step_val=1, current_step=job.current_step, steps_completed=job.steps_completed, remaining_steps=remaining_steps, total_steps=job.steps_completed + remaining_steps))
-
             job.mark_n_steps_completed(1, retval, job.steps_completed + remaining_steps)
 
-        print("===312.1===", "state", dict(current_step=job.current_step, steps_completed=job.steps_completed, percent_completed=job.percent_completed))
         self.state_store.update(job)
 
         if job.should_be_requeued():

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -46,7 +46,7 @@ class JobRunner(Generic[JobType]):
         except GoToEnd as exc:
             print("===311.1===", "GoToEnd", dict(step_val=job.steps_completed, current_step=job.current_step, steps_completed=job.steps_completed, remaining_steps=0, total_steps=job.steps_completed))
             job.mark_step_n_completed(
-                job.steps_completed, exc.retval, job.steps_completed
+                job.steps_completed, exc.retval, job.steps_completed + 1
             )
             LOG.info(
                 "User requested to go to end of workflow - return value: %s",

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -44,6 +44,7 @@ class JobRunner(Generic[JobType]):
             LOG.info("User requested to abort job: %s", exc)
             job.mark_aborted(exc.message)
         except GoToEnd as exc:
+            print("===311.1===", "GoToEnd", dict(step_val=job.steps_completed, current_step=job.current_step, steps_completed=job.steps_completed, remaining_steps=0, total_steps=job.steps_completed))
             job.mark_step_n_completed(
                 job.steps_completed, exc.retval, job.steps_completed
             )
@@ -78,6 +79,8 @@ class JobRunner(Generic[JobType]):
                 default=0,
             )
 
+            print("===311.2===", "GoToStep", dict(step_val=index, current_step=job.current_step, steps_completed=job.steps_completed, remaining_steps=remaining_steps, total_steps=job.steps_completed + remaining_steps))
+
             job.mark_step_n_completed(
                 index, exc.retval, job.steps_completed + remaining_steps
             )
@@ -93,6 +96,8 @@ class JobRunner(Generic[JobType]):
                 default=0,
             )
 
+            print("===311.3===", "SkipNSteps", dict(step_val=exc.n + 1, current_step=job.current_step, steps_completed=job.steps_completed, remaining_steps=remaining_steps, total_steps=job.steps_completed + remaining_steps))
+
             job.mark_n_steps_completed(
                 exc.n + 1, exc.retval, job.steps_completed + remaining_steps
             )
@@ -106,8 +111,11 @@ class JobRunner(Generic[JobType]):
                 map(len, filter(lambda steps: steps[0][0] is None, paths)), default=0
             )
 
+            print("===311.4===", "return", dict(step_val=1, current_step=job.current_step, steps_completed=job.steps_completed, remaining_steps=remaining_steps, total_steps=job.steps_completed + remaining_steps))
+
             job.mark_n_steps_completed(1, retval, job.steps_completed + remaining_steps)
 
+        print("===312.1===", "state", dict(current_step=job.current_step, steps_completed=job.steps_completed, percent_completed=job.percent_completed))
         self.state_store.update(job)
 
         if job.should_be_requeued():

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -135,6 +135,8 @@ class Workflow:
                 raise ValueError(err)
 
             step = WorkflowStep(self, func, label)
+            print("===111.1===", step, step.name)
+            print("===111.2===", step, step.label)
 
             if label:
                 self._labels[label] = len(self)

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -23,24 +23,17 @@ class Workflow:
     def __init__(self, unique_name: str) -> None:
         self.unique_name = unique_name
         self._steps: list[WorkflowStep] = []
-        self._labels: dict[str, int] = {}
+        self._step_names: dict[str, int] = {}
 
     def __getitem__(self, key: int | str) -> WorkflowStep:
         try:
-            if isinstance(key, int):
-                return self._steps[key]
-            else:
-                index = self._labels[key]
-                return self._steps[index]
+            index = self.get_index_by_step_name(key) if isinstance(key, str) else key
+            return self._steps[index]
         except IndexError:
             raise IndexError(
                 f'Workflow "{self.unique_name}" has {len(self)} steps '
                 f"- tried to access step #{key}"
             ) from None
-        except KeyError:
-            raise KeyError(
-                f'No label named "{key}" is registered in Workflow "{self.unique_name}"'
-            )
 
     def __iter__(self) -> Iterator[WorkflowStep]:
         return iter(self._steps)
@@ -95,19 +88,19 @@ class Workflow:
             return len(self)
 
         if isinstance(exc, GoToStep):
-            return self.get_label_index(exc.label) if exc.is_label else exc.n
+            return self.get_index_by_step_name(exc.step_name) if exc.is_step_name else exc.n
 
         if isinstance(exc, SkipNSteps):
             return index + 1 + exc.n
 
         return index + 1
 
-    def get_label_index(self, label: str) -> int:
+    def get_index_by_step_name(self, step_name: str) -> int:
         try:
-            return self._labels[label]
+            return self._step_names[step_name]
         except KeyError:
             raise KeyError(
-                f'No label named "{label}" is registered in '
+                f'No step named "{step_name}" is registered in '
                 f'Workflow "{self.unique_name}"'
             )
 
@@ -118,7 +111,6 @@ class Workflow:
     def step(
         self,
         *,
-        label: str | None = None,
         paths: list[ErgateError | None] | None = None,
     ) -> CallableTypeHint: ...
 
@@ -126,20 +118,12 @@ class Workflow:
         self,
         func: CallableTypeHint | None = None,
         *,
-        label: str | None = None,
         paths: list[ErgateError | None] | None = None,
     ) -> CallableTypeHint | WorkflowStepTypeHint:
         def _decorate(func: CallableTypeHint) -> WorkflowStepTypeHint:
-            if label and label in self._labels:
-                err = f'A workflow step with label "{label}" is already registered.'
-                raise ValueError(err)
+            step = WorkflowStep(self, func)
 
-            step = WorkflowStep(self, func, label)
-            print("===111.1===", step, step.name)
-            print("===111.2===", step, step.label)
-
-            if label:
-                self._labels[label] = len(self)
+            self._step_names[step.name] = len(self)
 
             self._steps.append(step)
 

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -88,7 +88,7 @@ class Workflow:
             return len(self)
 
         if isinstance(exc, GoToStep):
-            return self.get_index_by_step_name(exc.step_name) if exc.is_step_name else exc.n
+            return exc.n if exc.is_index else self.get_index_by_step_name(exc.step_name)
 
         if isinstance(exc, SkipNSteps):
             return index + 1 + exc.n

--- a/ergate/workflow_step.py
+++ b/ergate/workflow_step.py
@@ -21,13 +21,11 @@ class WorkflowStep(Generic[CallableSpec, CallableRetval]):
         self,
         workflow: Workflow,
         callable: Callable[CallableSpec, CallableRetval],
-        label: str | None = None,
     ) -> None:
         self.workflow = workflow
         self.callable = callable
         self.arg_info = build_function_arg_info(callable)
         self.paths: list[ErgateError | None] = [None]
-        self.label: str | None = label
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
This PR replaces the `label` feature of Ergeats, which allows manually specifying a string label for a workflow step which can be explicitly referenced with `GoToStep`, with the use of the workflow step function names.  This allows for every step to have a unique label without duplicative code for manually specifying labels.

Thanks to @prryplatypus, developer of Ergate, for the idea.