### PR TITLE
Accept functions as argument for `GoToStep` rather than function names.  Precalculate paths.

### DIFF
--- a/docs/docs/basics/defining-workflow-path-hints.md
+++ b/docs/docs/basics/defining-workflow-path-hints.md
@@ -31,7 +31,7 @@ def step_1() -> int:
 @workflow.step(paths=[GoToStepPath("step_3")])
 def step_2(number: int) -> None:
     print("Hello, I am step 2")
-    raise GoToStep("step_3", retval=2)
+    raise GoToStep(step_3, retval=2)
 
 @workflow.step(path=[GoToEndPath()])
 def step_5() -> None:
@@ -47,7 +47,7 @@ def step_3(number: int) -> int:
 def step_4(number: int) -> int:
     print("Hello, I am step 4")
     if number % 2:
-        raise GoToStep("step_7", retval=4)
+        raise GoToStep(step_7, retval=4)
     if number > 6:
         raise GoToEnd()
     return 4
@@ -102,7 +102,7 @@ workflow = Workflow(unique_name="workflow_with_paths_2")
 @workflow.step(paths=[GoToStepPath("step_two")])
 def step_one() -> None:
     print("Hello, I am step 1.")
-    raise GoToStep("step_two")
+    raise GoToStep(step_two)
 
 @workflow.step(paths=[GoToStepPath("weekday"), GoToStepPath("saturday")])
 def step_two() -> None:
@@ -112,10 +112,10 @@ def step_two() -> None:
     
     if today.weekday() < 5:
         print("Today is a weekday.  Do a weekday task.")
-        raise GoToStep("weekday")
+        raise GoToStep(weekday)
     if today.weekday() == 5:
         print("Today is Saturday.  Do a Saturday task.")
-        raise GoToStep("saturday")
+        raise GoToStep(saturday)
         
     print("Today is a Sunday.  Proceed to the next step.")
     return None
@@ -123,17 +123,17 @@ def step_two() -> None:
 @workflow.step(paths=[GoToStepPath("step_three")])
 def sunday() -> None:
     print("Hello, I am Sunday step.")
-    raise GoToStep("step_three")
+    raise GoToStep(step_three)
 
 @workflow.step(paths=[GoToStepPath("step_three")])
 def weekday() -> None:
     print("Hello, I am the extra weekday step.")
-    raise GoToStep("step_three")
+    raise GoToStep(step_three)
 
 @workflow.step(paths=[GoToStepPath("step_three")])
 def saturday() -> None:
     print("Hello, I am the extra saturday step.")
-    raise GoToStep("step_three")
+    raise GoToStep(step_three)
 
 @workflow.step
 def step_three() -> None:

--- a/docs/docs/basics/manual-step-ordering.md
+++ b/docs/docs/basics/manual-step-ordering.md
@@ -1,9 +1,9 @@
 # Using workflow step names for manual ordering
 
-Workflow steps may be manually ordered and redirected by use of `GoToStep` and step names.
+Workflow steps may be manually ordered and redirected by use of `GoToEnd`, GoToStep` and `SkipNSteps` exceptions.
 
-Workflow ordering can be preempted and redirected by raising the `GoToStep` exception, passing either the workflow step 
-function name or its numeric index.
+Workflow ordering can be preempted and redirected by raising the `GoToStep` exception, passing the workflow step 
+function along with the optional return value.
 
 Workflows may also be advanced directly to completion by raising the `GoToEnd` exception.
 
@@ -11,7 +11,8 @@ Workflows may also be advanced by a set number of steps by raising the `SkipNSte
 
 ## Defining manual workflow order
 
-The following workflow contains five steps in total, which are executed in a specific order as directed by the step names.
+The following workflow contains five steps in total, which are executed in a specific order as directed by the 
+exceptions.
 
 ```py title="my_ordered_workflow.py"
 from ergate import GoToEnd, GoToStep, Workflow
@@ -25,7 +26,7 @@ def step_1() -> None:
 @workflow.step
 def step_2() -> None:
     print("Hello, I am step 2")
-    raise GoToStep("step_4")
+    raise GoToStep(step_4)
 
 @workflow.step
 def step_3() -> None:
@@ -34,7 +35,7 @@ def step_3() -> None:
 @workflow.step
 def step_4() -> None:
     print("Hello, I am step 4")
-    raise GoToStep("step_5")
+    raise GoToStep(step_5)
 
 @workflow.step
 def step_5() -> None:
@@ -78,18 +79,18 @@ def step_1(input_value) -> None:
     
     match input_value:
         case "a":
-            raise GoToStep("step_a2")
+            raise GoToStep(step_a2)
         case "b":
-            raise GoToStep("step_b2")
+            raise GoToStep(step_b2)
         case "c":
-            raise GoToStep("step_c2")
+            raise GoToStep(step_c2)
         case _:
-            raise GoToStep("step_default2")
+            raise GoToStep(step_default2)
 
 @workflow.step
 def step_default2() -> None:
     print("Hello, I am step default.2")
-    raise GoToStep("step_4")
+    raise GoToStep(step_4)
 
 @workflow.step
 def step_a2() -> None:
@@ -98,7 +99,7 @@ def step_a2() -> None:
 @workflow.step
 def step_a3() -> None:
     print("Hello, I am step a.3")
-    raise GoToStep("step_4")
+    raise GoToStep(step_4)
 
 @workflow.step
 def step_b2() -> None:
@@ -107,7 +108,7 @@ def step_b2() -> None:
 @workflow.step
 def step_b3() -> None:
     print("Hello, I am step b.3")
-    raise GoToStep("step_4")
+    raise GoToStep(step_4)
 
 @workflow.step
 def step_c2() -> None:
@@ -146,7 +147,7 @@ If `input_value` is `c`, the workflow path is:
 2. `step_c2`
 3. `step_c3`
 
-with `step_4` skipped by `GoToEnd` having been raised in `step_c3`.
+with `step_4` skipped by the `GoToEnd` raised in `step_c3`.
 
 If `input_value` is anything else, the workflow path is:
 

--- a/ergate/__init__.py
+++ b/ergate/__init__.py
@@ -8,7 +8,7 @@ from .exceptions import (
     InvalidDefinitionError,
     ReverseGoToError,
     SkipNSteps,
-    UnknownStepNameError,
+    UnknownStepError,
     ValidationError,
 )
 from .job import Job
@@ -38,7 +38,7 @@ __all__ = [
     "SkipNSteps",
     "SkipNStepsPath",
     "StateStoreProtocol",
-    "UnknownStepNameError",
+    "UnknownStepError",
     "ValidationError",
     "Workflow",
     "WorkflowStep",

--- a/ergate/exceptions.py
+++ b/ergate/exceptions.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from pydantic import ValidationError  # noqa: F401
 
+from .workflow_step import WorkflowStep
+
 
 class ErgateError(Exception):
     """Base class for ergate exceptions."""
@@ -38,27 +40,9 @@ class GoToEnd(ErgateError):  # noqa: N818
 class GoToStep(ErgateError):  # noqa: N818
     """Raised from a step to go to a specific step by its index or string label."""
 
-    def __init__(self, value: int | str, *, retval: Any = None):
-        self.value = value
+    def __init__(self, step: WorkflowStep, *, retval: Any = None):
+        self.step = step
         self.retval = retval
-
-    @property
-    def is_index(self) -> bool:
-        return isinstance(self.value, int)
-
-    @property
-    def n(self) -> int:
-        assert isinstance(self.value, int)
-        return self.value
-
-    @property
-    def is_step_name(self) -> bool:
-        return isinstance(self.value, str)
-
-    @property
-    def step_name(self) -> str:
-        assert isinstance(self.value, str)
-        return self.value
 
 
 class SkipNSteps(ErgateError):  # noqa: N818

--- a/ergate/exceptions.py
+++ b/ergate/exceptions.py
@@ -15,7 +15,7 @@ class ReverseGoToError(ErgateError):
     """Raised when a workflow/step attempts to `go to` an earlier step."""
 
 
-class UnknownStepNameError(ErgateError):
+class UnknownStepError(ErgateError):
     """Raised when a workflow/step attempts to `go to` an unknown step."""
 
 

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -46,12 +46,12 @@ class JobRunner(Generic[JobType]):
                 LOG.info("User requested to abort job: %s", exc)
                 job.mark_aborted(exc.message)
             except GoToEnd as exc:
-                job.mark_step_n_completed(
-                    job.steps_completed, exc.retval, job.steps_completed + 1
-                )
                 LOG.info(
                     "User requested to go to end of workflow - return value: %s",
                     exc.retval,
+                )
+                job.mark_step_n_completed(
+                    job.steps_completed, exc.retval, job.steps_completed + 1
                 )
             except GoToStep as exc:
                 index = workflow.get_step_index(exc.step)

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -33,6 +33,9 @@ class JobRunner(Generic[JobType]):
         step_to_run = workflow[job.current_step]
         paths = workflow.calculate_paths(job.current_step)
 
+        for i, path in enumerate(paths):
+            print(f"===511.1=== {workflow.unique_name}.{job.current_step}.{i}: {path}")
+
         job.mark_running(step_to_run)
         self.state_store.update(job)
 

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -54,21 +54,14 @@ class JobRunner(Generic[JobType]):
                     exc.retval,
                 )
             except GoToStep as exc:
-                if exc.is_index:
-                    index = exc.n
-                    LOG.info(
-                        "User requested to go to step: %s - return value: %s",
-                        index,
-                        exc.retval,
-                    )
-                else:
-                    index = workflow.get_index_by_step_name(exc.step_name)
-                    LOG.info(
-                        "User requested to go to step: %s (%s) - return value: %s",
-                        exc.step_name,
-                        index,
-                        exc.retval,
-                    )
+                index = workflow.get_step_index(exc.step)
+
+                LOG.info(
+                    "User requested to go to step: %s (%s) - return value: %s",
+                    exc.step.name,
+                    index,
+                    exc.retval,
+                )
 
                 if index <= job.current_step:
                     raise ReverseGoToError(
@@ -81,7 +74,7 @@ class JobRunner(Generic[JobType]):
                         len(path)
                         for path in paths
                         if isinstance(path[0][0], GoToStepPath)
-                        and path[0][0].value == exc.value
+                        and path[0][0].step_name == exc.step_name
                     ),
                     default=len(workflow) - job.current_step,
                 )

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -72,7 +72,7 @@ class JobRunner(Generic[JobType]):
                         len(path)
                         for path in paths
                         if isinstance(path[0][0], GoToStepPath)
-                        and path[0][0].step_name == exc.step_name
+                        and path[0][0].step_name == exc.step.name
                     ),
                     default=len(workflow) - job.current_step,
                 )

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -31,10 +31,13 @@ class JobRunner(Generic[JobType]):
 
         workflow = self.workflow_registry[job.workflow_name]
         step_to_run = workflow[job.current_step]
-        paths = workflow.calculate_paths(job.current_step)
+        paths = workflow.paths[job.current_step]
 
         for i, path in enumerate(paths):
-            print(f"===511.1=== {workflow.unique_name}.{job.current_step}.{i}: {path}")
+            print(
+                f"===511.1=== {workflow.unique_name}.{job.current_step}.{i}: ",
+                [step[0].step_name for step in path]
+            )
 
         job.mark_running(step_to_run)
         self.state_store.update(job)

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -36,7 +36,7 @@ class JobRunner(Generic[JobType]):
         for i, path in enumerate(paths):
             print(
                 f"===511.1=== {workflow.unique_name}.{job.current_step}.{i}: ",
-                [step[0].step_name for step in path]
+                [step[1] for step in path]
             )
 
         job.mark_running(step_to_run)

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -54,16 +54,14 @@ class JobRunner(Generic[JobType]):
                     job.steps_completed, exc.retval, job.steps_completed + 1
                 )
             except GoToStep as exc:
-                index = workflow.get_step_index(exc.step)
-
                 LOG.info(
                     "User requested to go to step: %s (%s) - return value: %s",
                     exc.step.name,
-                    index,
+                    exc.step.index,
                     exc.retval,
                 )
 
-                if index <= job.current_step:
+                if exc.step.index <= job.current_step:
                     raise ReverseGoToError(
                         "User attempted to go to an earlier step, "
                         "which is not permitted."
@@ -80,7 +78,7 @@ class JobRunner(Generic[JobType]):
                 )
 
                 job.mark_step_n_completed(
-                    index, exc.retval, job.steps_completed + remaining_steps
+                    exc.step.index, exc.retval, job.steps_completed + remaining_steps
                 )
             except SkipNSteps as exc:
                 LOG.info("User requested to skip %d steps", exc.n)

--- a/ergate/job_runner.py
+++ b/ergate/job_runner.py
@@ -33,12 +33,6 @@ class JobRunner(Generic[JobType]):
         step_to_run = workflow[job.current_step]
         paths = workflow.paths[job.current_step]
 
-        for i, path in enumerate(paths):
-            print(
-                f"===511.1=== {workflow.unique_name}.{job.current_step}.{i}: ",
-                [step[1] for step in path]
-            )
-
         job.mark_running(step_to_run)
         self.state_store.update(job)
 

--- a/ergate/paths.py
+++ b/ergate/paths.py
@@ -9,26 +9,8 @@ class GoToEndPath(WorkflowPath):
 class GoToStepPath(WorkflowPath):
     """WorkflowPath class for the `GoToStep` exception."""
 
-    def __init__(self, value: int | str) -> None:
-        self.value = value
-
-    @property
-    def is_index(self) -> bool:
-        return isinstance(self.value, int)
-
-    @property
-    def n(self) -> int:
-        assert isinstance(self.value, int)
-        return self.value
-
-    @property
-    def is_step_name(self) -> bool:
-        return isinstance(self.value, str)
-
-    @property
-    def step_name(self) -> str:
-        assert isinstance(self.value, str)
-        return self.value
+    def __init__(self, step_name: str) -> None:
+        self.step_name = step_name
 
 
 class NextStepPath(WorkflowPath):

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -93,13 +93,7 @@ class Workflow:
         return paths
 
     def calculate_paths(self, index: int) -> list[list[WorkflowPathTypeHint]]:
-        paths = self._calculate_paths(index, initial=True)
-        print(
-            f"===411.1=== Calculating paths in workflow {self.unique_name} ",
-            f"from step {self[index].name} ({index}): {len(paths)} paths: ",
-            list(map(len, paths))
-        )
-        return paths
+        return self._calculate_paths(index, initial=True)
 
     def update_paths(self) -> None:
         self._paths = {step.index: self.calculate_paths(step.index) for step in self}

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -90,7 +90,7 @@ class Workflow:
     def calculate_paths(self, index: int) -> list[list[WorkflowPathTypeHint]]:
         print(
             f"===411.1=== Calculating paths in workflow {self.unique_name} "
-            f"from step {self[index]} ({index})"
+            f"from step {self[index].name} ({index})"
         )
         return self._calculate_paths(index, initial=True)
 

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -112,6 +112,15 @@ class Workflow:
 
         return index + 1
 
+    def get_step_index(self, step: WorkflowStep) -> int:
+        try:
+            return self._steps.index(step)
+        except ValueError:
+            raise UnknownStepError(
+                f'No step named "{step.name}" is registered in '
+                f'Workflow "{self.unique_name}"'
+            )
+
     def get_index_by_step_name(self, step_name: str) -> int:
         try:
             return self._step_names[step_name]

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -9,7 +9,7 @@ from typing import (
     overload,
 )
 
-from .exceptions import ReverseGoToError, UnknownStepNameError
+from .exceptions import ReverseGoToError, UnknownStepError
 from .paths import GoToEndPath, GoToStepPath, NextStepPath, SkipNStepsPath, WorkflowPath
 from .workflow_step import WorkflowStep
 
@@ -116,7 +116,7 @@ class Workflow:
         try:
             return self._step_names[step_name]
         except KeyError:
-            raise UnknownStepNameError(
+            raise UnknownStepError(
                 f'No step named "{step_name}" is registered in '
                 f'Workflow "{self.unique_name}"'
             )

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -1,11 +1,9 @@
-from types import NoneType
 from typing import (
     Callable,
     Iterator,
     ParamSpec,
     TypeAlias,
     TypeVar,
-    get_type_hints,
     overload,
 )
 
@@ -130,19 +128,8 @@ class Workflow:
         paths: list[WorkflowPath] | None = None,
     ) -> CallableTypeHint | WorkflowStepTypeHint:
         def _decorate(func: CallableTypeHint) -> WorkflowStepTypeHint:
-            step = WorkflowStep(self, func, len(self._steps))
-
+            step = WorkflowStep(self, func, len(self._steps), paths=paths)
             self._steps.append(step)
-
-            if paths:
-                step.paths = paths
-
-            hints = get_type_hints(func)
-            if hints["return"] is not NoneType and not any(
-                isinstance(path, NextStepPath) for path in step.paths
-            ):
-                step.paths.append(NextStepPath())
-
             return step
 
         if func is None:

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -123,6 +123,10 @@ class Workflow:
                 f'Workflow "{self.unique_name}"'
             )
 
+    def register(self) -> "Workflow":
+        self.update_paths()
+        return self
+
     @overload
     def step(self, func: CallableTypeHint) -> WorkflowStepTypeHint: ...
 
@@ -142,7 +146,6 @@ class Workflow:
         def _decorate(func: CallableTypeHint) -> WorkflowStepTypeHint:
             step = WorkflowStep(self, func, len(self), paths=paths)
             self._steps.append(step)
-            self.update_paths()
             return step
 
         if func is None:

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -103,9 +103,7 @@ class Workflow:
             return len(self)
 
         if isinstance(path, GoToStepPath):
-            return (
-                path.n if path.is_index else self.get_index_by_step_name(path.step_name)
-            )
+            return self.get_index_by_step_name(path.step_name)
 
         if isinstance(path, SkipNStepsPath):
             return index + 1 + path.n

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -27,7 +27,7 @@ class Workflow:
         self._step_names: dict[str, int] = {}
 
     def __getitem__(self, key: int | str) -> WorkflowStep:
-        index = self.get_index_by_step_name(key) if isinstance(key, str) else key
+        index = self.get_step_index_by_name(key) if isinstance(key, str) else key
 
         try:
             return self._steps[index]
@@ -103,7 +103,7 @@ class Workflow:
             return len(self)
 
         if isinstance(path, GoToStepPath):
-            return self.get_index_by_step_name(path.step_name)
+            return self.get_step_index_by_name(path.step_name)
 
         if isinstance(path, SkipNStepsPath):
             return index + 1 + path.n
@@ -119,7 +119,7 @@ class Workflow:
                 f'Workflow "{self.unique_name}"'
             )
 
-    def get_index_by_step_name(self, step_name: str) -> int:
+    def get_step_index_by_name(self, step_name: str) -> int:
         try:
             return self._step_names[step_name]
         except KeyError:

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -104,24 +104,14 @@ class Workflow:
 
         return index + 1
 
-    def get_step_index(self, step: WorkflowStep) -> int:
+    def get_step_index_by_name(self, step_name: str) -> int:
         try:
-            return self._steps.index(step)
-        except ValueError:
+            return next(step.index for step in self._steps if step.name == step_name)
+        except StopIteration:
             raise UnknownStepError(
-                f'No step named "{step.name}" is registered in '
+                f'No step named "{step_name}" is registered in '
                 f'Workflow "{self.unique_name}"'
             )
-
-    def get_step_index_by_name(self, step_name: str) -> int:
-        for idx, step in enumerate(self._steps):
-            if step.name == step_name:
-                return idx
-
-        raise UnknownStepError(
-            f'No step named "{step_name}" is registered in '
-            f'Workflow "{self.unique_name}"'
-        )
 
     @overload
     def step(self, func: CallableTypeHint) -> WorkflowStepTypeHint: ...
@@ -140,7 +130,7 @@ class Workflow:
         paths: list[WorkflowPath] | None = None,
     ) -> CallableTypeHint | WorkflowStepTypeHint:
         def _decorate(func: CallableTypeHint) -> WorkflowStepTypeHint:
-            step = WorkflowStep(self, func)
+            step = WorkflowStep(self, func, len(self._steps))
 
             self._steps.append(step)
 

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -55,7 +55,7 @@ class Workflow:
                 )
                 raise ValueError(err)
 
-            if path not in self._steps[index].paths:
+            if path not in self[index].paths:
                 err = (
                     f"Failed to calculate workflow path from step {index}: "
                     f"path not registered: {path}"
@@ -79,7 +79,7 @@ class Workflow:
             paths.append([current_step])
             return paths
 
-        for next_path in self._steps[next_index].paths:
+        for next_path in self[next_index].paths:
             paths += self._calculate_paths(next_index, path=next_path)
 
         if not initial:
@@ -90,7 +90,7 @@ class Workflow:
     def calculate_paths(self, index: int) -> list[list[WorkflowPathTypeHint]]:
         print(
             f"===411.1=== Calculating paths in workflow {self.unique_name} "
-            f"from step {self._steps[index]} ({index})"
+            f"from step {self[index]} ({index})"
         )
         return self._calculate_paths(index, initial=True)
 
@@ -108,7 +108,7 @@ class Workflow:
 
     def get_step_index_by_name(self, step_name: str) -> int:
         try:
-            return next(step.index for step in self._steps if step.name == step_name)
+            return next(step.index for step in iter(self) if step.name == step_name)
         except StopIteration:
             raise UnknownStepError(
                 f'No step named "{step_name}" is registered in '
@@ -132,7 +132,7 @@ class Workflow:
         paths: list[WorkflowPath] | None = None,
     ) -> CallableTypeHint | WorkflowStepTypeHint:
         def _decorate(func: CallableTypeHint) -> WorkflowStepTypeHint:
-            step = WorkflowStep(self, func, len(self._steps), paths=paths)
+            step = WorkflowStep(self, func, len(self), paths=paths)
             self._steps.append(step)
             return step
 

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -88,6 +88,10 @@ class Workflow:
         return paths
 
     def calculate_paths(self, index: int) -> list[list[WorkflowPathTypeHint]]:
+        print(
+            f"===411.1=== Calculating paths in workflow {self.unique_name} "
+            f"from step {self._steps[index]} ({index})"
+        )
         return self._calculate_paths(index, initial=True)
 
     def _find_next_step(self, index: int, path: WorkflowPath) -> int:

--- a/ergate/workflow.py
+++ b/ergate/workflow.py
@@ -93,11 +93,13 @@ class Workflow:
         return paths
 
     def calculate_paths(self, index: int) -> list[list[WorkflowPathTypeHint]]:
+        paths = self._calculate_paths(index, initial=True)
         print(
-            f"===411.1=== Calculating paths in workflow {self.unique_name} "
-            f"from step {self[index].name} ({index})"
+            f"===411.1=== Calculating paths in workflow {self.unique_name} ",
+            f"from step {self[index].name} ({index}): {len(paths)} paths: ",
+            list(map(len, paths))
         )
-        return self._calculate_paths(index, initial=True)
+        return paths
 
     def update_paths(self) -> None:
         self._paths = {step.index: self.calculate_paths(step.index) for step in self}

--- a/ergate/workflow_registry.py
+++ b/ergate/workflow_registry.py
@@ -20,4 +20,4 @@ class WorkflowRegistry:
         if workflow.unique_name in self._workflows:
             err = f'A workflow named "{workflow.unique_name}" is already registered'
             raise ValueError(err)
-        self._workflows[workflow.unique_name] = workflow
+        self._workflows[workflow.unique_name] = workflow.register()

--- a/ergate/workflow_step.py
+++ b/ergate/workflow_step.py
@@ -55,7 +55,9 @@ class WorkflowStep(Generic[CallableSpec, CallableRetval]):
         prepared = [*paths]
 
         hints = get_type_hints(self.callable)
-        if hints["return"] is not NoneType and not any(isinstance(path, NextStepPath) for path in prepared):
+        if hints["return"] is not NoneType and not any(
+                isinstance(path, NextStepPath) for path in prepared
+        ):
             prepared.append(NextStepPath())
 
         return prepared

--- a/ergate/workflow_step.py
+++ b/ergate/workflow_step.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
 from types import NoneType
-from typing import TYPE_CHECKING, Any, Callable, Generic, ParamSpec, TypeVar, get_type_hints
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    ParamSpec,
+    TypeVar,
+    get_type_hints,
+)
 
 from .depends_cache import DependsCache
 from .inspect import build_function_arg_info

--- a/ergate/workflow_step.py
+++ b/ergate/workflow_step.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
-from typing import TYPE_CHECKING, Any, Callable, Generic, ParamSpec, TypeVar
+from types import NoneType
+from typing import TYPE_CHECKING, Any, Callable, Generic, ParamSpec, TypeVar, get_type_hints
 
 from .depends_cache import DependsCache
 from .inspect import build_function_arg_info
@@ -22,12 +23,14 @@ class WorkflowStep(Generic[CallableSpec, CallableRetval]):
         workflow: Workflow,
         callable: Callable[CallableSpec, CallableRetval],
         index: int,
+        *,
+        paths: list[WorkflowPath] | None = None,
     ) -> None:
         self.index = index
         self.workflow = workflow
         self.callable = callable
         self.arg_info = build_function_arg_info(callable)
-        self.paths: list[WorkflowPath] = [NextStepPath()]
+        self.paths = self._prepare_paths(paths)
 
     @property
     def name(self) -> str:
@@ -44,6 +47,18 @@ class WorkflowStep(Generic[CallableSpec, CallableRetval]):
                 user_context,
                 last_return_value,
             )
+
+    def _prepare_paths(self, paths: list[WorkflowPath] | None) -> list[WorkflowPath]:
+        if paths is None:
+            return [NextStepPath()]
+
+        prepared = [*paths]
+
+        hints = get_type_hints(self.callable)
+        if hints["return"] is not NoneType and not any(isinstance(path, NextStepPath) for path in prepared):
+            prepared.append(NextStepPath())
+
+        return prepared
 
     def __call__(
         self,

--- a/ergate/workflow_step.py
+++ b/ergate/workflow_step.py
@@ -64,7 +64,7 @@ class WorkflowStep(Generic[CallableSpec, CallableRetval]):
 
         hints = get_type_hints(self.callable)
         if hints["return"] is not NoneType and not any(
-                isinstance(path, NextStepPath) for path in prepared
+            isinstance(path, NextStepPath) for path in prepared
         ):
             prepared.append(NextStepPath())
 

--- a/ergate/workflow_step.py
+++ b/ergate/workflow_step.py
@@ -21,7 +21,9 @@ class WorkflowStep(Generic[CallableSpec, CallableRetval]):
         self,
         workflow: Workflow,
         callable: Callable[CallableSpec, CallableRetval],
+        index: int,
     ) -> None:
+        self.index = index
         self.workflow = workflow
         self.callable = callable
         self.arg_info = build_function_arg_info(callable)


### PR DESCRIPTION
This PR makes a collection of changes to Ergeats:

* `GoToStep` now accepts the `WorkflowStep` functions themselves as its argument, rather than the string names of those functions.
* `WorkflowStep` objects now store their index internally.
* Paths are precalculated for workflow steps once at startup rather than for every run.
* `UnknownStepNameError` is renamed to `UnknownStepError`
* `Workflow.get_index_by_step_name` is renamed to `get_step_index_by_name`.